### PR TITLE
Improve feature checks for OpenMPI 4

### DIFF
--- a/cmake/CheckMPISymbolIsRvalue.cmake
+++ b/cmake/CheckMPISymbolIsRvalue.cmake
@@ -1,0 +1,57 @@
+# This file is part of CMake-MPIhelper.
+#
+# Copyright (C)
+#   2015 RWTH Aachen University, Federal Republic of Germany
+#
+# See the file LICENSE in the package base directory for details.
+
+# Set the minimum required CMake version.
+cmake_minimum_required(VERSION 2.6)
+
+
+include(CheckSymbolIsRvalue)
+
+
+## \brief Wrapper for check_symbol_exists to test \p symbol in MPI environment.
+#
+# \details Sets MPI environment and calls check_symbol_exists for \p symbol.
+#
+#
+# \param symbol Symbol to test.
+# \param variable Variable to be set, if symbol exists.
+#
+# \return If \p symbol was found, \p variable will be set true. In any other
+#   case \p variable will become false.
+#
+function(CHECK_MPI_SYMBOL_IS_RVALUE symbol variable)
+	# Note: a check against CMake cache is not needed in this function, thus all
+	# called functions implement such a check.
+
+	# search for MPI environment
+	IF (POLICY CMP0074)
+		CMAKE_POLICY(PUSH)
+		#if MPI_ROOT is set, use it for finding MPI
+		CMAKE_POLICY(SET CMP0074 NEW)
+	ENDIF ()
+
+	find_package(MPI)
+
+	IF (POLICY CMP0074)
+		CMAKE_POLICY(POP)
+	ENDIF ()
+
+	if (MPI_C_FOUND)
+		# set environment
+		set(CMAKE_REQUIRED_FLAGS "${MPI_C_COMPILE_FLAGS}")
+		set(CMAKE_REQUIRED_DEFINITIONS "")
+		set(CMAKE_REQUIRED_INCLUDES "${MPI_C_INCLUDE_PATH}")
+		set(CMAKE_REQUIRED_LIBRARIES "${MPI_C_LIBRARIES}")
+
+		# check for symbol
+		check_symbol_is_rvalue(${symbol} "mpi.h" ${variable})
+		return()
+	endif ()
+
+	# set variable to false, if MPI was not found
+	set(${variable} false)
+endfunction(CHECK_MPI_SYMBOL_IS_RVALUE)

--- a/cmake/CheckSymbolIsRvalue.cmake
+++ b/cmake/CheckSymbolIsRvalue.cmake
@@ -1,0 +1,152 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+CheckSymbolIsRvalue
+-----------------
+
+Provides a macro to check if a symbol exists as a function, variable,
+or macro in ``C`` and can be used as a rvalue.
+
+.. command:: check_symbol_exists
+
+  .. code-block:: cmake
+
+    check_symbol_is_rvalue(<symbol> <files> <variable>)
+
+  Check that the ``<symbol>`` is available after including given header
+  ``<files>`` and store the result in a ``<variable>``.  Specify the list
+  of files in one argument as a semicolon-separated list.
+  ``<variable>`` will be created as an internal cache variable.
+
+If the header files define the symbol as a macro it is still checked to be
+a valid rvalue.  If the header files declare the symbol
+as a function or variable then the symbol must also be available for
+linking (so intrinsics may not be detected).
+If the symbol is a type, enum value, or intrinsic it will not be recognized
+(consider using :module:`CheckTypeSize` or :module:`CheckCSourceCompiles`).
+If the check needs to be done in C++, consider using
+:module:`CheckCXXSymbolExists` instead.
+
+The following variables may be set before calling this macro to modify
+the way the check is run:
+
+``CMAKE_REQUIRED_FLAGS``
+  string of compile command line flags.
+``CMAKE_REQUIRED_DEFINITIONS``
+  a :ref:`;-list <CMake Language Lists>` of macros to define (-DFOO=bar).
+``CMAKE_REQUIRED_INCLUDES``
+  a :ref:`;-list <CMake Language Lists>` of header search paths to pass to
+  the compiler.
+``CMAKE_REQUIRED_LINK_OPTIONS``
+  a :ref:`;-list <CMake Language Lists>` of options to add to the link command.
+``CMAKE_REQUIRED_LIBRARIES``
+  a :ref:`;-list <CMake Language Lists>` of libraries to add to the link
+  command. See policy :policy:`CMP0075`.
+``CMAKE_REQUIRED_QUIET``
+  execute quietly without messages.
+
+For example:
+
+.. code-block:: cmake
+
+  include(CheckSymbolExists)
+
+  # Check for macro SEEK_SET
+  check_symbol_exists(SEEK_SET "stdio.h" HAVE_SEEK_SET)
+  # Check for function fopen
+  check_symbol_exists(fopen "stdio.h" HAVE_FOPEN)
+#]=======================================================================]
+
+include_guard(GLOBAL)
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0054 NEW) # if() quoted variables not dereferenced
+
+macro(CHECK_SYMBOL_IS_RVALUE SYMBOL FILES VARIABLE)
+  if(CMAKE_C_COMPILER_LOADED)
+    __CHECK_SYMBOL_IS_RVALUE_IMPL("${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckSymbolExists.c" "${SYMBOL}" "${FILES}" "${VARIABLE}" )
+  elseif(CMAKE_CXX_COMPILER_LOADED)
+    __CHECK_SYMBOL_IS_RVALUE_IMPL("${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckSymbolExists.cxx" "${SYMBOL}" "${FILES}" "${VARIABLE}" )
+  else()
+    message(FATAL_ERROR "CHECK_SYMBOL_IS_RVALUE needs either C or CXX language enabled")
+  endif()
+endmacro()
+
+macro(__CHECK_SYMBOL_IS_RVALUE_IMPL SOURCEFILE SYMBOL FILES VARIABLE)
+  if(NOT DEFINED "${VARIABLE}" OR "x${${VARIABLE}}" STREQUAL "x${VARIABLE}")
+    set(CMAKE_CONFIGURABLE_FILE_CONTENT "/* */\n")
+    set(MACRO_CHECK_SYMBOL_IS_RVALUE_FLAGS ${CMAKE_REQUIRED_FLAGS})
+    if(CMAKE_REQUIRED_LINK_OPTIONS)
+      set(CHECK_SYMBOL_IS_RVALUE_LINK_OPTIONS
+        LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS})
+    else()
+      set(CHECK_SYMBOL_IS_RVALUE_LINK_OPTIONS)
+    endif()
+    if(CMAKE_REQUIRED_LIBRARIES)
+      set(CHECK_SYMBOL_IS_RVALUE_LIBS
+        LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    else()
+      set(CHECK_SYMBOL_IS_RVALUE_LIBS)
+    endif()
+    if(CMAKE_REQUIRED_INCLUDES)
+      set(CMAKE_SYMBOL_EXISTS_INCLUDES
+        "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}")
+    else()
+      set(CMAKE_SYMBOL_EXISTS_INCLUDES)
+    endif()
+    foreach(FILE ${FILES})
+      string(APPEND CMAKE_CONFIGURABLE_FILE_CONTENT
+        "#include <${FILE}>\n")
+    endforeach()
+    string(APPEND CMAKE_CONFIGURABLE_FILE_CONTENT "
+int main(int argc, char** argv)
+{
+  (void)argv;
+  argc = (int)${SYMBOL};
+  return argc;
+}")
+    unset(_CSE_CHECK_NON_MACRO)
+
+    configure_file("${CMAKE_ROOT}/Modules/CMakeConfigurableFile.in"
+      "${SOURCEFILE}" @ONLY)
+
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Looking for ${SYMBOL}")
+    endif()
+    try_compile(${VARIABLE}
+      ${CMAKE_BINARY_DIR}
+      "${SOURCEFILE}"
+      COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+      ${CHECK_SYMBOL_IS_RVALUE_LINK_OPTIONS}
+      ${CHECK_SYMBOL_IS_RVALUE_LIBS}
+      CMAKE_FLAGS
+      -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_SYMBOL_IS_RVALUE_FLAGS}
+      "${CMAKE_SYMBOL_EXISTS_INCLUDES}"
+      OUTPUT_VARIABLE OUTPUT)
+    if(${VARIABLE})
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Looking for rvalue ${SYMBOL} - found")
+      endif()
+      set(${VARIABLE} 1 CACHE INTERNAL "Have rvalue ${SYMBOL}")
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Determining if the ${SYMBOL} "
+        "is rvale passed with the following output:\n"
+        "${OUTPUT}\nFile ${SOURCEFILE}:\n"
+        "${CMAKE_CONFIGURABLE_FILE_CONTENT}\n")
+    else()
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Looking for rvalue ${SYMBOL} - not found")
+      endif()
+      set(${VARIABLE} "" CACHE INTERNAL "Have rvalue ${SYMBOL}")
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Determining if the ${SYMBOL} "
+        "is rvalue failed with the following output:\n"
+        "${OUTPUT}\nFile ${SOURCEFILE}:\n"
+        "${CMAKE_CONFIGURABLE_FILE_CONTENT}\n")
+    endif()
+    unset(CMAKE_CONFIGURABLE_FILE_CONTENT)
+  endif()
+endmacro()
+
+cmake_policy(POP)


### PR DESCRIPTION
OpenMPI 4 defines some removed functions as macros, which finally result in
compile errors pointing out the old symbol was removed and what to use
instead.

The new _is_rvalue checks, whether a symbol can be used as an rvalue.
This can be used for variables, functions and macros. Any deprecation
warning/error will trigger.

The CheckSymbolIsRvalue.cmake is a copy of upstream CheckSymbolExists.cmake and just changed the code generated for the try_compile.